### PR TITLE
perf improvements to correct_motion

### DIFF
--- a/src/torch_motion_correction/correct_motion.py
+++ b/src/torch_motion_correction/correct_motion.py
@@ -6,12 +6,13 @@ from torch_image_interpolation import sample_image_2d
 from torch_fourier_shift import fourier_shift_dft_2d
 
 from torch_motion_correction.evaluate_deformation_grid import (
-    evaluate_deformation_grid,
+    evaluate_deformation_grid, evaluate_deformation_grid_at_t,
 )
 
+
 def correct_motion(
-    image: torch.Tensor,
-    deformation_grid: torch.Tensor,
+    image: torch.Tensor,  # (t, h, w)
+    deformation_grid: torch.Tensor,  # (yx, t, h, w)
     grad: bool = False,
     device: torch.device = None,
 ) -> torch.Tensor:
@@ -20,37 +21,39 @@ def correct_motion(
     else:
         image = image.to(device)
         deformation_grid = deformation_grid.to(device)
-        
+
     t, _, _ = image.shape
+    _, gt, gh, gw = deformation_grid.shape
     normalized_t = torch.linspace(0, 1, steps=t, device=image.device)
-    
-        
+
     # Use conditional gradient context to save memory
     gradient_context = torch.enable_grad() if grad else torch.no_grad()
-    
+
     with gradient_context:
         # correct motion in each frame
         corrected_frames = [
             _correct_frame(
                 frame=frame,
-                deformation_grid=deformation_grid,
-                t=frame_t,
+                frame_deformation_grid=evaluate_deformation_grid_at_t(
+                    deformation_grid=deformation_grid,
+                    t=frame_t,
+                    grid_shape=(10 * gh, 10 * gw)
+                )
             )
             for frame, frame_t
             in zip(image, normalized_t)
         ]
     corrected_frames = torch.stack(corrected_frames, dim=0).detach()
-    return corrected_frames # (t, h, w)
+    return corrected_frames  # (t, h, w)
 
 
 def _correct_frame(
     frame: torch.Tensor,
-    deformation_grid: torch.Tensor,
-    t: float  # [0, 1]
+    frame_deformation_grid: torch.Tensor,  # (yx, h, w)
 ) -> torch.Tensor:
-
-    # grab frame dimensions
+    # grab frame and deformation grid dimensions
     h, w = frame.shape
+    _, gh, gw = frame_deformation_grid.shape
 
     # prepare a grid of pixel positions
     pixel_grid = coordinate_grid(
@@ -58,22 +61,19 @@ def _correct_frame(
         device=frame.device,
     )  # (h, w, 2) yx coords
 
-    dim_lengths = torch.as_tensor([h - 1, w - 1], device=frame.device, dtype=torch.float32)
-    normalized_pixel_grid = pixel_grid / dim_lengths
-
-    # add normalized time coordinate to every pixel coordinate
-    # (h, w, 2) -> (h, w, 3)
-    # yx -> tyx
-    tyx = F.pad(normalized_pixel_grid, pad=(1, 0), value=t)
-
-    # evaluate interpolated shifts at every pixel
-    shifts_px = evaluate_deformation_grid(
-        deformation_grid=deformation_grid,
-        tyx=tyx,
+    # interpolate oversampled per frame deformation grid at each pixel position
+    image_dim_lengths = torch.as_tensor([h - 1, w - 1], device=frame.device, dtype=torch.float32)
+    deformation_grid_dim_lengths = torch.as_tensor([gh - 1, gw - 1], device=frame.device, dtype=torch.float32)
+    normalized_pixel_grid = pixel_grid / image_dim_lengths
+    deformation_grid_interpolants = normalized_pixel_grid * deformation_grid_dim_lengths
+    pixel_shifts = sample_image_2d(
+        image=frame,
+        coordinates=deformation_grid_interpolants,
+        interpolation='bicubic'
     )
 
     # find pixel positions to sample image data at, accounting for deformations
-    deformed_pixel_coords = pixel_grid + shifts_px
+    deformed_pixel_coords = pixel_grid + pixel_shifts
 
     # sample original image data
     corrected_frame = sample_image_2d(
@@ -118,12 +118,12 @@ def correct_motion_batched(
     else:
         image = image.to(device)
         deformation_grid = deformation_grid.to(device)
-        
+
     t, h, w = image.shape
-    
+
     # Use conditional gradient context to save memory
     gradient_context = torch.enable_grad() if grad else torch.no_grad()
-    
+
     with gradient_context:
         if batch_size is None or batch_size >= t:
             # Process all frames at once
@@ -144,7 +144,7 @@ def correct_motion_batched(
                 )
                 corrected_frames.append(batch_corrected)
             corrected_frames = torch.cat(corrected_frames, dim=0)
-    
+
     return corrected_frames.detach()
 
 
@@ -170,34 +170,35 @@ def _correct_frames(
     corrected_frames: torch.Tensor
         (t, h, w) or (batch_t, h, w) corrected frames
     """
-    
+
     batch_t, h, w = frames.shape
-    
+
     # Prepare coordinate grid once for all frames
     pixel_grid = coordinate_grid(
         image_shape=(h, w),
         device=frames.device,
     )  # (h, w, 2) yx coords
-    
+
     # Normalize pixel grid once
     dim_lengths = torch.as_tensor([h - 1, w - 1], device=frames.device, dtype=torch.float32)
     normalized_pixel_grid = pixel_grid / dim_lengths
-    
+
     # Create normalized time coordinates for all frames
     normalized_t = torch.linspace(0, 1, steps=batch_t, device=frames.device)
     if frame_offset > 0:
         # Adjust time coordinates for batch offset
         total_frames = deformation_grid.shape[1]  # Assuming deformation_grid is (2, t, h, w)
-        normalized_t = torch.linspace(frame_offset / (total_frames - 1), 
-                                   (frame_offset + batch_t - 1) / (total_frames - 1), 
-                                   steps=batch_t, device=frames.device)
-    
+        normalized_t = torch.linspace(frame_offset / (total_frames - 1),
+                                      (frame_offset + batch_t - 1) / (total_frames - 1),
+                                      steps=batch_t, device=frames.device
+                                      )
+
     # Add time coordinate to pixel grid for all frames at once
     # (h, w, 2) -> (batch_t, h, w, 3)
     tyx = normalized_pixel_grid.unsqueeze(0).expand(batch_t, -1, -1, -1)  # (batch_t, h, w, 2)
     t_coords = normalized_t.view(-1, 1, 1, 1).expand(-1, h, w, 1)  # (batch_t, h, w, 1)
     tyx = torch.cat([t_coords, tyx], dim=-1)  # (batch_t, h, w, 3)
-    
+
     # Evaluate deformation grid for all frames at once
     # Reshape to (batch_t * h * w, 3) for batch evaluation
     tyx_flat = tyx.view(-1, 3)  # (batch_t * h * w, 3)
@@ -205,14 +206,14 @@ def _correct_frames(
         deformation_grid=deformation_grid,
         tyx=tyx_flat,
     )  # (batch_t * h * w, 2)
-    
+
     # Reshape back to (batch_t, h, w, 2)
     shifts_px = shifts_px_flat.view(batch_t, h, w, 2)
-    
+
     # Find deformed pixel coordinates for all frames
     pixel_grid_expanded = pixel_grid.unsqueeze(0).expand(batch_t, -1, -1, -1)  # (batch_t, h, w, 2)
     deformed_pixel_coords = pixel_grid_expanded + shifts_px  # (batch_t, h, w, 2)
-    
+
     # Sample image data for all frames
     corrected_frames = []
     for i in range(batch_t):
@@ -222,10 +223,11 @@ def _correct_frames(
             interpolation='bicubic',
         )
         corrected_frames.append(corrected_frame)
-    
+
     corrected_frames = torch.stack(corrected_frames, dim=0)
-    
+
     return corrected_frames
+
 
 def correct_motion_fast(
     image: torch.Tensor,
@@ -258,29 +260,31 @@ def correct_motion_fast(
     else:
         image = image.to(device)
         deformation_grid = deformation_grid.to(device)
-    
+
     # Check that deformation field has single patch dimensions
     if deformation_grid.shape[-2:] != (1, 1):
         raise ValueError(f"Expected single patch deformation field with shape (2, t, 1, 1), "
-                       f"but got shape {deformation_grid.shape}. "
-                       f"Final two dimensions must be (1, 1) for single patch correction.")
-    
+                         f"but got shape {deformation_grid.shape}. "
+                         f"Final two dimensions must be (1, 1) for single patch correction."
+                         )
+
     t, h, w = image.shape
-    
+
     # Extract shifts from deformation field (2, t, 1, 1) -> (t, 2)
     shifts = einops.rearrange(deformation_grid, 'c t 1 1 -> t c')
-    shifts *= -1 # flip for phase shift
+    shifts *= -1  # flip for phase shift
 
     print(f"Single patch correction: applying shifts to {t} frames")
     print(f"Shift range: y=[{shifts[:, 0].min():.2f}, {shifts[:, 0].max():.2f}], "
-          f"x=[{shifts[:, 1].min():.2f}, {shifts[:, 1].max():.2f}] pixels")
-    
+          f"x=[{shifts[:, 1].min():.2f}, {shifts[:, 1].max():.2f}] pixels"
+          )
+
     # Convert image to frequency domain for efficient shifting
-    
+
     image_fft = torch.fft.rfftn(image, dim=(-2, -1))  # (t, h, w_freq)
-    
+
     # Apply shifts using fourier_shift_dft_2d
-    
+
     shifted_fft = fourier_shift_dft_2d(
         dft=image_fft,
         image_shape=(h, w),
@@ -288,7 +292,7 @@ def correct_motion_fast(
         rfft=True,
         fftshifted=False,
     )
-    
+
     corrected_frames = torch.fft.irfftn(shifted_fft, s=(h, w))
 
     return corrected_frames

--- a/src/torch_motion_correction/evaluate_deformation_grid.py
+++ b/src/torch_motion_correction/evaluate_deformation_grid.py
@@ -1,13 +1,40 @@
+import einops
 import torch
-from typing import Tuple
+import torch.nn.functional as F
 from torch_cubic_spline_grids import CubicCatmullRomGrid3d
 
 
 def evaluate_deformation_grid(
-    deformation_grid: torch.Tensor,  # (nt, nh, nw)
+    deformation_grid: torch.Tensor,  # (c, nt, nh, nw)
     tyx: torch.Tensor,  # (..., 3)
-) -> torch.Tensor:
+) -> torch.Tensor:  # (
     """Evaluate shifts from deformation field data."""
     deformation_field = CubicCatmullRomGrid3d.from_grid_data(deformation_grid).to(deformation_grid.device)
     predicted_shifts = deformation_field(tyx)
     return predicted_shifts
+
+
+def evaluate_deformation_grid_at_t(
+    deformation_grid: torch.Tensor,  # (c, nt, nh, nw)
+    t: float,  # [0, 1]
+    grid_shape: tuple[int, int],  # (h, w)
+) -> torch.Tensor:
+    """Evaluate a grid of shifts at a specific timepoint from deformation field data.
+
+     output: (tyx, h, w)
+     """
+    h, w = grid_shape
+    y = torch.linspace(0, 1, steps=h, device=deformation_grid.device)
+    x = torch.linspace(0, 1, steps=w, device=deformation_grid.device)
+
+    # Create meshgrid and flatten to get (h*w, 2) array of yx coordinates
+    yy, xx = torch.meshgrid(y, x, indexing='ij')
+    yx_grid = einops.rearrange([yy, xx], "yx h w -> (h w) yx")
+
+    # Add t coordinate using F.pad to create tyx triplets
+    tyx_grid = F.pad(yx_grid, (1, 0), value=t)  # (h*w, 3)
+
+    # Evaluate deformation grid and return as (tyx, h, w)
+    shifts = evaluate_deformation_grid(deformation_grid, tyx_grid)  # (h*w, c)
+    shifts = einops.rearrange(shifts, "(h w) tyx -> tyx h w", h=h, w=w)
+    return shifts


### PR DESCRIPTION
speedup correct motion by evaluating per-pixel shifts using bicubic interpolation on oversampled deformation grid with F.grid_sample (via torch_image_interpolation)

Previously all shifts were directly evaluated with the cubic spline grids from torch-cubic-spline-grids which is good but a bit slow here